### PR TITLE
Allow new name for Google Maps API key

### DIFF
--- a/opfmaps-providers/google/src/main/java/org/onepf/opfmaps/google/GoogleMapProvider.java
+++ b/opfmaps-providers/google/src/main/java/org/onepf/opfmaps/google/GoogleMapProvider.java
@@ -62,6 +62,7 @@ public class GoogleMapProvider extends BaseOPFMapProvider {
 
     @Override
     public boolean isKeyPresented(@NonNull final Context context) {
-        return OPFChecks.hasMetadata(context, "com.google.android.maps.v2.API_KEY");
+        return OPFChecks.hasMetadata(context, "com.google.android.maps.v2.API_KEY") ||
+               OPFChecks.hasMetadata(context, "com.google.android.geo.API_KEY");
     }
 }


### PR DESCRIPTION
Google Maps SDK has changed its default name for the API key, from
`com.google.android.maps.v2.API_KEY` to `com.google.android.geo.API_KEY`.

The old syntax is still supported.

This patch allows OPFMaps provider to accept the new syntax.

References:
https://developers.google.com/maps/documentation/android-api/signup#add_the_api_key_to_your_application
